### PR TITLE
Surchs/issue17

### DIFF
--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import json
 
 import click
 from bids import BIDSLayout
@@ -41,12 +40,14 @@ def bagel(bids_dir, output_dir, level, validate):
                 subject=subject, session=session, extension=[".nii", ".nii.gz"]
             ):
                 image_list.append(
-                    models.Imaging(hasContrastType=bids_file.get_entities().get("suffix"))
+                    models.Imaging(
+                        hasContrastType=bids_file.get_entities().get("suffix"),
+                    )
                 )
-            session_list.append(models.Session(identifier=session, hasAcquisition=image_list))
+            session_list.append(models.Session(label=session, hasAcquisition=image_list))
         # pyBIDS strips the "sub-" prefix, but we want to add it back
-        subject_list.append(models.Subject(identifier=f"sub-{subject}", hasSession=session_list))
-    dataset = models.Dataset(identifier=str(bids_dataset_name), hasSamples=subject_list)
+        subject_list.append(models.Subject(label=f"sub-{subject}", hasSession=session_list))
+    dataset = models.Dataset(label=str(bids_dataset_name), hasSamples=subject_list)
 
     with open(Path(output_dir) / f"{bids_dataset_name}.json", "w") as f:
         f.write(dataset.json(indent=2))

--- a/bagelbids/merge.py
+++ b/bagelbids/merge.py
@@ -43,7 +43,7 @@ def get_id(data: dict, mode: str = "bids") -> dict:
         # TODO: replace this hack and instead change the annotator output model
         return {
             sub["id"]: dict(
-                label=sub["id"], **{key: val for (key, val) in sub.items() if not "id" in key}
+                label=sub["id"], **{key: val for (key, val) in sub.items() if "id" not in key}
             )
             for sub in data["subjects"]
         }
@@ -78,8 +78,8 @@ def merge_on_subject(bids_json: dict, demo_json: dict) -> list:
     if not is_subset(demo_json.keys(), bids_json.keys()):
         warnings.warn(
             Warning(
-                "There are subjects in the demographics file that do not exist in the BIDS dataset! "
-                "Their IDs are:\n"
+                "There are subjects in the demographics file that aren't exist in the BIDS dataset"
+                "! Their IDs are:\n"
                 + "\n".join(
                     [str(val) for val in set(demo_json.keys()).difference(set(bids_json.keys()))]
                 )
@@ -127,7 +127,8 @@ def cli(bids_path, demo_path, out_path):
     context = generate_context()
 
     # TODO: revisit this implementation. It is concerningly implicit
-    # we instantiate the datamodel here for two purposes: validation, and to add uuids if they don't exist yet
+    # we instantiate the datamodel here for two purposes: validation,
+    # and to add uuids if they don't exist yet
     model = models.Dataset.parse_obj(merge_json(bids_json, demo_json))
     context.update(**model.dict())
 

--- a/bagelbids/merge.py
+++ b/bagelbids/merge.py
@@ -23,7 +23,7 @@ def generate_context():
             if name == "schemaKey":
                 fields[name] = "@type"
             elif name == "identifier":
-                fields[name] = "@type"
+                fields[name] = "@id"
             elif name not in fields:
                 fields[name] = {"@id": "bagel:" + name}
 

--- a/bagelbids/merge.py
+++ b/bagelbids/merge.py
@@ -78,8 +78,8 @@ def merge_on_subject(bids_json: dict, demo_json: dict) -> list:
     if not is_subset(demo_json.keys(), bids_json.keys()):
         warnings.warn(
             Warning(
-                "There are subjects in the demographics file that aren't exist in the BIDS dataset"
-                "! Their IDs are:\n"
+                "There are subjects in the demographics file "
+                "that do not exist in the BIDS dataset! Their IDs are:\n"
                 + "\n".join(
                     [str(val) for val in set(demo_json.keys()).difference(set(bids_json.keys()))]
                 )

--- a/bagelbids/merge.py
+++ b/bagelbids/merge.py
@@ -36,12 +36,12 @@ def is_subset(sample: List, reference: List) -> bool:
 
 def get_id(data: dict, mode: str = "bids") -> dict:
     if mode == "bids":
-        return {sub["identifier"]: sub for sub in data["hasSamples"]}
+        return {sub["label"]: sub for sub in data["hasSamples"]}
     elif mode == "demo":
         # TODO: replace this hack and instead change the annotator output model
         return {
             sub["id"]: dict(
-                identifier=sub["id"], **{key: val for (key, val) in sub.items() if not "id" in key}
+                label=sub["id"], **{key: val for (key, val) in sub.items() if not "id" in key}
             )
             for sub in data["subjects"]
         }

--- a/bagelbids/models.py
+++ b/bagelbids/models.py
@@ -20,7 +20,7 @@ class Session(BaseModel):
 class Subject(BaseModel):
     identifier: Optional[UUID] = None
     label: str
-    hasSession: List[Session] = []
+    hasSession: Optional[List[Session]] = None
     age: Optional[float] = None
     sex: Optional[str] = None
     diagnosis: Optional[str] = None

--- a/bagelbids/models.py
+++ b/bagelbids/models.py
@@ -4,13 +4,17 @@ from typing import List, Literal, Optional
 from pydantic import BaseModel, Field, constr
 
 
+UUID_PATTERN = (
+    r"[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$"
+)
+BAGEL_UUID_PATTERN = r"^bagel:" + UUID_PATTERN
+
+
 class Bagel(BaseModel):
     """identifier has to be a valid UUID prepended by the bagel: namespace
     by default, a random (uuid4) string UUID will be created"""
 
-    identifier: constr(
-        regex=r"^bagel:[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$"
-    ) = "bagel:" + str(uuid.uuid4())
+    identifier: constr(regex=BAGEL_UUID_PATTERN) = "bagel:" + str(uuid.uuid4())
 
 
 class Imaging(Bagel):

--- a/bagelbids/models.py
+++ b/bagelbids/models.py
@@ -1,24 +1,30 @@
-from uuid import UUID
+import uuid
 
 from typing import List, Literal, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, constr
 
 
-class Imaging(BaseModel):
-    identifier: Optional[UUID] = None
+class Bagel(BaseModel):
+    """identifier has to be a valid UUID prepended by the bagel: namespace
+    by default, a random (uuid4) string UUID will be created"""
+
+    identifier: constr(
+        regex=r"^bagel:[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$"
+    ) = "bagel:" + str(uuid.uuid4())
+
+
+class Imaging(Bagel):
     hasContrastType: str
     schemaKey: Literal["Imaging"] = Field("Imaging", readOnly=True)
 
 
-class Session(BaseModel):
-    identifier: Optional[UUID] = None
+class Session(Bagel):
     label: str
     hasAcquisition: List[Imaging]
     schemaKey: Literal["Session"] = Field("Session", readOnly=True)
 
 
-class Subject(BaseModel):
-    identifier: Optional[UUID] = None
+class Subject(Bagel):
     label: str
     hasSession: Optional[List[Session]] = None
     age: Optional[float] = None
@@ -27,8 +33,7 @@ class Subject(BaseModel):
     schemaKey: Literal["Subject"] = Field("Subject", readOnly=True)
 
 
-class Dataset(BaseModel):
-    identifier: Optional[UUID] = None
+class Dataset(Bagel):
     label: str
     hasSamples: List[Subject]
     schemaKey: Literal["Dataset"] = Field("Dataset", readOnly=True)

--- a/bagelbids/models.py
+++ b/bagelbids/models.py
@@ -1,20 +1,25 @@
+from uuid import UUID
+
 from typing import List, Literal, Optional
 from pydantic import BaseModel, Field
 
 
 class Imaging(BaseModel):
+    identifier: Optional[UUID] = None
     hasContrastType: str
     schemaKey: Literal["Imaging"] = Field("Imaging", readOnly=True)
 
 
 class Session(BaseModel):
-    identifier: str
+    identifier: Optional[UUID] = None
+    label: str
     hasAcquisition: List[Imaging]
     schemaKey: Literal["Session"] = Field("Session", readOnly=True)
 
 
 class Subject(BaseModel):
-    identifier: str
+    identifier: Optional[UUID] = None
+    label: str
     hasSession: List[Session] = []
     age: Optional[float] = None
     sex: Optional[str] = None
@@ -23,6 +28,7 @@ class Subject(BaseModel):
 
 
 class Dataset(BaseModel):
-    identifier: str
+    identifier: Optional[UUID] = None
+    label: str
     hasSamples: List[Subject]
     schemaKey: Literal["Dataset"] = Field("Dataset", readOnly=True)

--- a/bagelbids/models.py
+++ b/bagelbids/models.py
@@ -1,7 +1,7 @@
 import uuid
 
 from typing import List, Literal, Optional
-from pydantic import BaseModel, Field, constr
+from pydantic import BaseModel, Field
 
 
 UUID_PATTERN = (
@@ -14,7 +14,9 @@ class Bagel(BaseModel):
     """identifier has to be a valid UUID prepended by the bagel: namespace
     by default, a random (uuid4) string UUID will be created"""
 
-    identifier: constr(regex=BAGEL_UUID_PATTERN) = "bagel:" + str(uuid.uuid4())
+    identifier: str = Field(
+        regex=BAGEL_UUID_PATTERN, default_factory=lambda: "bagel:" + str(uuid.uuid4())
+    )
 
 
 class Imaging(Bagel):
@@ -33,7 +35,7 @@ class Subject(Bagel):
     hasSession: Optional[List[Session]] = None
     age: Optional[float] = None
     sex: Optional[str] = None
-    diagnosis: Optional[str] = None
+    diagnosis: Optional[List[str]] = None
     schemaKey: Literal["Subject"] = Field("Subject", readOnly=True)
 
 

--- a/bagelbids/tests/test_cli.py
+++ b/bagelbids/tests/test_cli.py
@@ -36,9 +36,11 @@ def test_processing_bids_synth_creates_json(runner, bids_synthetic, tmp_path):
 
 def test_that_subject_id_includes_the_full_sub_prefix(runner, bids_synthetic, tmp_path):
     runner.invoke(bagel, ["--bids_dir", bids_synthetic, "--output_dir", tmp_path])
-    with open(tmp_path / "synthetic.json", 'r') as f:
+    with open(tmp_path / "synthetic.json", "r") as f:
         bids_json = json.load(f)
-    
-    subs = [sub for sub in bids_json['hasSamples'] if "sub-04" in sub['identifier']]
-    assert len(subs) == 1, "We did not find a subject with the name of"
-    assert set(["01", "02"]).issubset([ses["identifier"] for ses in subs[0]["hasSession"]]), "The expected sessions are not found for subject 04"
+
+    subs = [sub for sub in bids_json["hasSamples"] if "sub-04" in sub["label"]]
+    assert len(subs) == 1, "We did not find a subject with the name of sub-04"
+    assert set(["01", "02"]).issubset(
+        [ses["label"] for ses in subs[0]["hasSession"]]
+    ), "The expected sessions are not found for subject 04"

--- a/bagelbids/tests/test_merge.py
+++ b/bagelbids/tests/test_merge.py
@@ -29,7 +29,7 @@ def bids_json():
 
 @pytest.fixture
 def bids_json_long(bids_json):
-    return {"hasSamples": bids_json["hasSamples"] + [{"identifier": 3, "extra_key": "three"}]}
+    )
 
 
 @pytest.fixture
@@ -64,7 +64,19 @@ def demo_json_path(demo_json, tmp_path):
     return json_path
 
 
-def test_merge_takes_input_arguments(runner, bids_json_path, demo_json_path, tmp_path):
+@pytest.fixture
+def target_json():
+    return {
+        "hasSamples": [
+            {"label": 1, "extra_key": "one", "special_key": "one"},
+            {"label": 2, "extra_key": "two", "special_key": "two"},
+        ],
+        "schemaKey": "Dataset",
+        "label": "BIDS dataset",
+    }
+
+
+def test_merge_creates_valid_data_model(runner, bids_json_path, demo_json_path, tmp_path):
     result = runner.invoke(
         cli,
         [
@@ -77,6 +89,13 @@ def test_merge_takes_input_arguments(runner, bids_json_path, demo_json_path, tmp
         ],
     )
     assert result.exit_code == 0
+    with open(tmp_path / "my_output.jsonld", "r") as f:
+        result = json.load(f)
+
+    try:
+        models.Dataset.parse_obj(result)
+    except ValidationError as e:
+        pytest.fail(f"The output of the merge CLI was not a valid dataset model: {e}")
 
 
 def test_get_id_unsupported_mode_fails():
@@ -86,12 +105,12 @@ def test_get_id_unsupported_mode_fails():
 
 def test_get_id(bids_json, demo_json):
     target_bids = {
-        1: {"identifier": 1, "extra_key": "one"},
-        2: {"identifier": 2, "extra_key": "two"},
+        1: {"label": 1, "extra_key": "one"},
+        2: {"label": 2, "extra_key": "two"},
     }
     target_demo = {
-        1: {"identifier": 1, "special_key": "one"},
-        2: {"identifier": 2, "special_key": "two"},
+        1: {"label": 1, "special_key": "one"},
+        2: {"label": 2, "special_key": "two"},
     }
     result_bids = get_id(bids_json, mode="bids")
     result_demo = get_id(demo_json, mode="demo")
@@ -100,13 +119,13 @@ def test_get_id(bids_json, demo_json):
 
 
 def test_merge_subject_lists():
-    # I give two identifier indexed dicts
+    # I give two label indexed dicts
     # and I expect to get a single, merged dict back that contains both
-    bids_example = {1: {"identifier": 1, "extra_key": 1}, 2: {"identifier": 2, "extra_key": 2}}
-    demo_example = {1: {"identifier": 1, "special_key": 1}, 2: {"identifier": 2, "special_key": 2}}
+    bids_example = {1: {"label": 1, "extra_key": 1}, 2: {"label": 2, "extra_key": 2}}
+    demo_example = {1: {"label": 1, "special_key": 1}, 2: {"label": 2, "special_key": 2}}
     target = [
-        {"identifier": 1, "extra_key": 1, "special_key": 1},
-        {"identifier": 2, "extra_key": 2, "special_key": 2},
+        {"label": 1, "extra_key": 1, "special_key": 1},
+        {"label": 2, "extra_key": 2, "special_key": 2},
     ]
 
     result = merge_on_subject(bids_example, demo_example)
@@ -114,24 +133,12 @@ def test_merge_subject_lists():
     assert result == target
 
 
-def test_merge_json(bids_json, demo_json):
-    target_json = {
-        "hasSamples": [
-            {"identifier": 1, "extra_key": "one", "special_key": "one"},
-            {"identifier": 2, "extra_key": "two", "special_key": "two"},
-        ]
-    }
+def test_merge_json(bids_json, demo_json, target_json):
     result = merge_json(bids_json, demo_json)
     assert result == target_json
 
 
-def test_merge_if_demo_has_additional_subjects(bids_json, demo_json_long):
-    target_json = {
-        "hasSamples": [
-            {"identifier": 1, "extra_key": "one", "special_key": "one"},
-            {"identifier": 2, "extra_key": "two", "special_key": "two"},
-        ]
-    }
+def test_merge_if_demo_has_additional_subjects(bids_json, demo_json_long, target_json):
     # If there are more subjects in the demo file than the BIDS dataset
     # we expect a warning that includes the subject IDs that will be stripped
     with pytest.warns(Warning, match=r"99"):
@@ -139,16 +146,11 @@ def test_merge_if_demo_has_additional_subjects(bids_json, demo_json_long):
     assert result == target_json
 
 
-def test_merge_if_bids_has_additional_subjects(bids_json_long, demo_json):
+def test_merge_if_bids_has_additional_subjects(bids_json_long, demo_json, target_json):
     # If there are more subjects in the BIDS dataset than in the demographic file
     # We will strip these subjects and we expect a warning that includes the
     # subject IDs that will be stripped.
-    target_json = {
-        "hasSamples": [
-            {"identifier": 1, "extra_key": "one", "special_key": "one"},
-            {"identifier": 2, "extra_key": "two", "special_key": "two"},
-        ]
-    }
+
     with pytest.warns(
         Warning,
         match=r"(?P<mismatch>There is a mismatch)(?:.+\n+.+)(?P<type>only present in the BIDS data)(?:.+\n+)(?P<sub>3)",
@@ -157,16 +159,12 @@ def test_merge_if_bids_has_additional_subjects(bids_json_long, demo_json):
     assert result == target_json
 
 
-def test_merge_if_bids_and_demo_have_additional_subjects(bids_json_long, demo_json_long):
+def test_merge_if_bids_and_demo_have_additional_subjects(
+    bids_json_long, demo_json_long, target_json
+):
     # If both the BIDS and the demographic file have additional subjects,
     # then we expect to get their intersection and remove any subject that is
     # unique to either file. Every time subjects are removed, a warning is expected
-    target_json = {
-        "hasSamples": [
-            {"identifier": 1, "extra_key": "one", "special_key": "one"},
-            {"identifier": 2, "extra_key": "two", "special_key": "two"},
-        ]
-    }
     with pytest.warns(Warning) as warning_record:
         result = merge_json(bids_json_long, demo_json_long)
 

--- a/bagelbids/tests/test_merge.py
+++ b/bagelbids/tests/test_merge.py
@@ -205,8 +205,14 @@ def test_merged_subjects_have_uuid_identifiers(runner, bids_json_path, demo_json
 
     # We just confirm that the identifier exists and contains the right name space
     try:
-        for subject in result["hasSamples"]:
-            # If the identifier string is a valid UUID then we can cast it to a UUID object
+        # If the identifier string is a valid UUID then we can cast it to a UUID object
+        subject_uuids = [
             uuid.UUID(subject.get("identifier").split(":")[1], version=4)
+            for subject in result["hasSamples"]
+        ]
     except ValueError:
         pytest.fail("At least one subject does not have a valid UUID identifier")
+
+    assert len(set(subject_uuids)) == len(
+        result["hasSamples"]
+    ), "The subject identifier UUIDs are not unique"

--- a/bagelbids/tests/test_merge.py
+++ b/bagelbids/tests/test_merge.py
@@ -3,8 +3,6 @@ Test the command line interface function to merge a BIDS and demographic json fi
 """
 import json
 import re
-from pathlib import Path
-import warnings
 
 import pytest
 from click.testing import CliRunner
@@ -162,7 +160,8 @@ def test_merge_if_bids_has_additional_subjects(bids_json_long, demo_json, target
 
     with pytest.warns(
         Warning,
-        match=r"(?P<mismatch>There is a mismatch)(?:.+\n+.+)(?P<type>only present in the BIDS data)(?:.+\n+)(?P<sub>3)",
+        match=r"(?P<mismatch>There is a mismatch)(?:.+\n+.+)"
+        r"(?P<type>only present in the BIDS data)(?:.+\n+)(?P<sub>3)",
     ):
         result = merge_json(bids_json_long, demo_json)
     assert result == target_json
@@ -178,7 +177,8 @@ def test_merge_if_bids_and_demo_have_additional_subjects(
         result = merge_json(bids_json_long, demo_json_long)
 
     assert re.match(
-        r"(?P<mismatch>There is a mismatch)(?:.+\n+.+)(?P<type>only present in the BIDS data)(?:.+\n+)(?P<sub>3)",
+        r"(?P<mismatch>There is a mismatch)(?:.+\n+.+)"
+        r"(?P<type>only present in the BIDS data)(?:.+\n+)(?P<sub>3)",
         warning_record[0].message.args[0],
     )
     assert re.match(r"(.+\n+)(99)", warning_record[1].message.args[0])


### PR DESCRIPTION
This PR adds UUIDs to the mergeed bagelbids jsonld file. The main change is that all pydantic classes now inherit from the Bagel base class which has the identifier attribute and defaults to a valid UUID string. 

When you make an instance of any of these classes, that instance will get an identifier attribute of the form `bagel:b0036494-e046-42b4-a094-647932e33463`, the second half is a UUID. This will become the node-id in when we upload the data to the graph. Because the UUID will be random, every instance should have a unique identifier.

The context creation method was also updated so that the identifier is correctly expanded to the `@id` jsonld keyword.

Fixes #17
Fixes https://github.com/neurobagel/project/issues/46