### PR TITLE
validate data dictionary

### DIFF
--- a/bagelbids/tests/conftest.py
+++ b/bagelbids/tests/conftest.py
@@ -15,6 +15,11 @@ def bids_synthetic(bids_path):
 
 
 @pytest.fixture(scope="session")
+def test_data():
+    return Path(__file__).absolute().parent / "data"
+
+
+@pytest.fixture(scope="session")
 def bids_invalid_synthetic(bids_path, bids_synthetic, tmp_path_factory):
     invalid_path = tmp_path_factory.mktemp("tmp_bids") / "synthetic_invalid"
     # We make a copy of the valid BIDS dataset and delete a required file to make it invalid

--- a/bagelbids/tests/data/README.md
+++ b/bagelbids/tests/data/README.md
@@ -4,7 +4,7 @@ Example inputs to the CLI
 
 | Ex#     | `.tsv`                                                        | `.json`                                                                          | Expect |
 |---------|---------------------------------------------------------------|----------------------------------------------------------------------------------|--------|
-| 1       | invalid, duplicate `participant` and `session` IDs            | valid, has `IsAbout` annotations for `participant` and `session` ID columns      | fail   |
+| 1       | invalid, non-unique combinations of `participant` and `session` IDs            | valid, has `IsAbout` annotations for `participant` and `session` ID columns      | fail   |
 | 2       | valid, unique `participant` and `session` IDs                 | same as example 1                                                                | pass   |
 | 3       | same as example 2                                             | valid BIDS data dictionary, BUT: does not contain Neurobagel `"Annotations"` key | fail   |
 | 4       | valid, has additional columns not described in `.json`        | same as example 1                                                                | pass   |

--- a/bagelbids/tests/data/README.md
+++ b/bagelbids/tests/data/README.md
@@ -2,41 +2,12 @@
 
 Example inputs to the CLI
 
-- example1: duplicate IDs in .tsv -> fail
-  - .tsv
-    - invalid
-    - has duplicate participantID-sessionID pairs
-  - .json
-    - is valid Neurobagel .json
-    - has tags for participant and session ID
-- example2: good data -> pass
-  - .tsv
-    - is valid
-    - has unique participant and session ID
-  - .json
-    - same as example1
-- example3: good data, but no annotations in .json -> fail
-  - .tsv
-    - same as example2
-  - .json
-    - is valid as BIDS
-    - BUT: is not valid as Neurobagel (no `"Annotations"` field)
-- example4: tsv has additional columns -> pass
-  - .tsv
-    - is valid
-    - BUT: has more columns than are annotated in the .json
-  - .json
-    - same as example 1
-- example5: categorical variable has extra values not in dictionary -> fail
-  - .tsv
-    - valid
-    - has additional unique value, not documented in .json
-  - .json
-    - same as example1
-- example6: valid data, .json includes missingValues attribute -> pass
-  - .tsv
-    - valid
-    - same as example5
-  - .json
-    - valid
-    - contains MissingValues attribute for categorical variable
+| Ex#     | `.tsv`                                                        | `.json`                                                                          | Expect |
+|---------|---------------------------------------------------------------|----------------------------------------------------------------------------------|--------|
+| 1       | invalid, duplicate `participant` and `session` IDs            | valid, has `IsAbout` annotations for `participant` and `session` ID columns      | fail   |
+| 2       | valid, unique `participant` and `session` IDs                 | same as example 1                                                                | pass   |
+| 3       | same as example 2                                             | valid BIDS data dictionary, BUT: does not contain Neurobagel `"Annotations"` key | fail   |
+| 4       | valid, has additional columns not described in `.json`        | same as example 1                                                                | pass   |
+| 5       | valid, has additional unique value, not documented in `.json` | same as example 1                                                                | fail   |
+| 6       | valid, same as example 5                                      | valid, contains `"MissingValues"` attribute for categorical variable             | pass   |
+| invalid | -                                                             | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |

--- a/bagelbids/tests/data/example_invalid.json
+++ b/bagelbids/tests/data/example_invalid.json
@@ -1,0 +1,38 @@
+{
+    "participant_id": {
+        "Description": "A participant ID",
+        "Annotations": {
+            "IsAbout": {
+                "Label": "Unique participant identifier"
+            }
+        }
+    },
+    "session_id": {
+        "Description": "A session ID",
+        "Annotations": {
+            "IsAbout": {
+                "Label": "Unique session identifier"
+            }
+        }
+    },
+    "group": {
+        "Description": "Group variable",
+        "Levels": {
+            "PAT": "Patient",
+            "CTRL": "Control subject"
+        },
+        "Annotations": {
+            "IsAbout": {
+                "Label": "Diagnosis"
+            },
+            "Levels": {
+                "PAT": {
+                    "Label": "Parkinson's disease"
+                },
+                "CTRL": {
+                    "Label": "Healthy Control"
+                }
+            }
+        }
+    }
+}

--- a/bagelbids/tests/test_cli.py
+++ b/bagelbids/tests/test_cli.py
@@ -9,9 +9,12 @@ def runner():
     return CliRunner()
 
 
-def test_cli_can_be_invoked(runner, test_data, tmp_path):
+def test_cli_can_run_pheno_subcommand(runner, test_data, tmp_path):
+    """Basic smoke test for the "pheno" subcommand"""
+    # TODO: when we have more than one subcommand, the CLI runner will have
+    # to specify the subcommand - until then the CLI behaves as if there was no subcommand
 
     result = runner.invoke(bagel, ["--pheno", test_data / "example2.tsv",
                                    "--dictionary", test_data / "example2.json",
                                    "--output", tmp_path])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, f"Errored out. STDOUT: {result.output}"

--- a/bagelbids/tests/test_cli.py
+++ b/bagelbids/tests/test_cli.py
@@ -9,12 +9,9 @@ def runner():
     return CliRunner()
 
 
-def test_cli_can_be_invoked(runner, tmp_path):
-    dir_p = tmp_path
-    demo_p = dir_p / "demo.tsv"
-    dict_p = dir_p / "dict.json"
-    demo_p.touch()
-    dict_p.touch()
+def test_cli_can_be_invoked(runner, test_data, tmp_path):
 
-    result = runner.invoke(bagel, ["--pheno", demo_p, "--dictionary", dict_p, "--output", dir_p])
+    result = runner.invoke(bagel, ["--pheno", test_data / "example2.tsv",
+                                   "--dictionary", test_data / "example2.json",
+                                   "--output", tmp_path])
     assert result.exit_code == 0

--- a/bagelbids/tests/test_pheno.py
+++ b/bagelbids/tests/test_pheno.py
@@ -1,25 +1,8 @@
 import json
 
 import pytest
-from typer.testing import CliRunner
 
-from bagelbids.cli import bagel, is_valid_data_dictionary, load_json
-
-
-@pytest.fixture
-def runner():
-    return CliRunner()
-
-
-def test_cli_validates_dictionary(runner, tmp_path, test_data):
-    dir_p = tmp_path
-    demo_p = dir_p / "demo.tsv"
-    dict_p = test_data / "example1.json"
-    demo_p.touch()
-    dict_p.touch()
-
-    result = runner.invoke(bagel, ["--pheno", demo_p, "--dictionary", dict_p, "--output", dir_p])
-    assert result.exit_code == 0, f"Errored out. STDOUT: {result.output}"
+from bagelbids.cli import is_valid_data_dictionary
 
 
 @pytest.mark.parametrize("input_p,is_valid", [

--- a/bagelbids/tests/test_pheno.py
+++ b/bagelbids/tests/test_pheno.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from bagelbids.cli import bagel, is_valid_data_dictionary, load_json
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_cli_validates_dictionary(runner, tmp_path, test_data):
+    dir_p = tmp_path
+    demo_p = dir_p / "demo.tsv"
+    dict_p = test_data / "example1.json"
+    demo_p.touch()
+    dict_p.touch()
+
+    result = runner.invoke(bagel, ["--pheno", demo_p, "--dictionary", dict_p, "--output", dir_p])
+    assert result.exit_code == 0, f"Errored out. STDOUT: {result.output}"
+
+
+@pytest.mark.parametrize("input_p,is_valid", [
+    ("example1.json", True),
+    ("example2.json", True),
+    ("example3.json", False),
+    ("example4.json", True),
+    ("example5.json", True),
+    ("example_invalid.json", False)
+])
+def test_validates_data_dictionary(test_data, input_p, is_valid):
+    """
+    Detects whether the provided data dictionary is valid under the schema.
+    Because the data dictionary schema is valid for BIDS data dictionaries without Neurobagel annotations,
+    this also detects whether the data dictionary has the required Neurobagel annotations.
+    """
+    with open(test_data / input_p, "r") as f:
+        data_dict = json.load(f)
+
+    result = is_valid_data_dictionary(data_dict)
+    assert result == is_valid

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     typer
     rich
     pydantic
+    jsonschema
 zip_safe = False
 packages = find:
 include_package_data = True


### PR DESCRIPTION
Closes #31 

Changes:
- added `test_pheno` to test the new subcommand
- `test_pheno` contains unit tests of methods inside of the `cli.py` module. `test_cli` has one (very basic) integration test that runs the actual CLI
- added additional test data
- 

Note: 
- Because we currently have only one subcommand (`pheno`), the CLI still behaves as if there was no subcommand. I.e. you can still call it with simply `bagel --pheno /my/pheno/file.tsv ...`). This will change as soon as we add a second subcommand
- This is all in one commit because I thought I was being clever with stacking my PRs...