### PR TITLE
pheno subcommand can serialize a graph instance

### DIFF
--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -5,7 +5,7 @@ import jsonschema
 import typer
 import pandas as pd
 
-from bagelbids import dictionary_models
+from bagelbids import dictionary_models, mappings
 
 
 bagel = typer.Typer()
@@ -51,15 +51,27 @@ def validate_inputs(data_dict: dict, pheno_df: pd.DataFrame) -> None:
     try:
         jsonschema.validate(data_dict, DICTIONARY_SCHEMA)
     except jsonschema.ValidationError as e:
-        raise ValueError("The provided data dictionary is not a valid Neurobagel data dictionary. "
-                         "Make sure that each annotated column contains an 'Annotations' key.") from e
-    
+        raise ValueError(
+            "The provided data dictionary is not a valid Neurobagel data dictionary. "
+            "Make sure that each annotated column contains an 'Annotations' key."
+        ) from e
+
+    # TODO: remove this validation when we start handling multiple participant and / or session ID columns
+    if ((len(get_columns_about(data_dict, concept=mappings.NEUROBAGEL["participant"])) > 1) |
+            (len(get_columns_about(data_dict, concept=mappings.NEUROBAGEL["session"])) > 1)):
+        raise ValueError(
+            "The provided data dictionary has more than one column about participant ID or session ID."
+            "Please make sure that only one column is annotated for participant and session IDs."
+        )
+
     if not are_inputs_compatible(data_dict, pheno_df):
-        raise LookupError("The provided data dictionary and phenotypic file are individually valid, "
-                          "but are not compatible. Make sure that you selected the correct data "
-                          "dictionary for your phenotyic file. Every column described in the data "
-                          "dictionary has to have a corresponding column with the same name in the "
-                          "phenotypic file")
+        raise LookupError(
+            "The provided data dictionary and phenotypic file are individually valid, "
+            "but are not compatible. Make sure that you selected the correct data "
+            "dictionary for your phenotyic file. Every column described in the data "
+            "dictionary has to have a corresponding column with the same name in the "
+            "phenotypic file"
+        )
 
 
 @bagel.command()

--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -13,8 +13,29 @@ bagel = typer.Typer()
 DICTIONARY_SCHEMA = dictionary_models.DataDictionary.schema()
 
 
-def load_json(data_dict_path: Path) -> dict:
-    with open(data_dict_path, "r") as f:
+def get_columns_about(data_dict: dict, concept: str) -> list:
+    """
+    Returns column names that have been annotated as "IsAbout" the desired concept.
+    Parameters
+    ----------
+    data_dict: dict
+        A valid Neurobagel annotated data dictionary must be provided.
+    concept: str
+        A (shorthand) IRI for a concept that a column can be "about"
+
+    Returns
+    list
+        List of column names that are "about" the desired concept
+
+    -------
+
+    """
+    return [col for col, annotations in data_dict.items()
+            if annotations["Annotations"]["IsAbout"]["TermURL"] == concept]
+
+
+def load_json(input_p: Path) -> dict:
+    with open(input_p, "r") as f:
         return json.load(f)
 
 

--- a/bagelbids/mappings.py
+++ b/bagelbids/mappings.py
@@ -11,3 +11,7 @@ NIDM = {
     "dti": "nidm:DiffusionTensor",
     "asl": "nidm:ArterialSpinLabeling",
 }
+NEUROBAGEL = {
+    "participant": "nb:ParticipantID",
+    "session": "nb:SessionID"
+}

--- a/bagelbids/tests/data/README.md
+++ b/bagelbids/tests/data/README.md
@@ -2,13 +2,16 @@
 
 Example inputs to the CLI
 
-| Ex#     | `.tsv`                                                        | `.json`                                                                          | Expect |
-|---------|---------------------------------------------------------------|----------------------------------------------------------------------------------|--------|
-| 1       | invalid, non-unique combinations of `participant` and `session` IDs            | valid, has `IsAbout` annotations for `participant` and `session` ID columns      | fail   |
-| 2       | valid, unique `participant` and `session` IDs                 | same as example 1                                                                | pass   |
-| 3       | same as example 2                                             | valid BIDS data dictionary, BUT: does not contain Neurobagel `"Annotations"` key | fail   |
-| 4       | valid, has additional columns not described in `.json`        | same as example 1                                                                | pass   |
-| 5       | valid, has additional unique value, not documented in `.json` | same as example 1                                                                | fail   |
-| 6       | valid, same as example 5                                      | valid, contains `"MissingValues"` attribute for categorical variable             | pass   |
-| invalid | -                                                             | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |
-| 7       | has fewer columns than are annotated in `.json`               | same as example 1                                                                | fail   |
+| Ex#     | `.tsv`                                                              | `.json`                                                                          | Expect |
+|---------|---------------------------------------------------------------------|----------------------------------------------------------------------------------|--------|
+| 1       | invalid, non-unique combinations of `participant` and `session` IDs | valid, has `IsAbout` annotations for `participant` and `session` ID columns      | fail   |
+| 2       | valid, unique `participant` and `session` IDs                       | same as example 1                                                                | pass   |
+| 3       | same as example 2                                                   | valid BIDS data dictionary, BUT: does not contain Neurobagel `"Annotations"` key | fail   |
+| 4       | valid, has additional columns not described in `.json`              | same as example 1                                                                | pass   |
+| 5       | valid, has additional unique value, not documented in `.json`       | same as example 1                                                                | fail   |
+| 6       | valid, same as example 5                                            | valid, contains `"MissingValues"` attribute for categorical variable             | pass   |
+| invalid | -                                                                   | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |
+| 7       | has fewer columns than are annotated in `.json`                     | same as example 1                                                                | fail   |
+| 8       | valid, based on ex2 has multiple participant_id columns             | valid, based on ex2 multiple participant_id column annotations                   | fail*  |
+
+`* this is expected to fail until we enable multiple participant_ID handling`.

--- a/bagelbids/tests/data/README.md
+++ b/bagelbids/tests/data/README.md
@@ -10,7 +10,7 @@ Example inputs to the CLI
 | 4       | valid, has additional columns not described in `.json`              | same as example 1                                                                | pass   |
 | 5       | valid, has additional unique value, not documented in `.json`       | same as example 1                                                                | fail   |
 | 6       | valid, same as example 5                                            | valid, contains `"MissingValues"` attribute for categorical variable             | pass   |
-| invalid | -                                                                   | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |
+| invalid | valid, only exists to be used together with the (invalid) .json     | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |
 | 7       | has fewer columns than are annotated in `.json`                     | same as example 1                                                                | fail   |
 | 8       | valid, based on ex2 has multiple participant_id columns             | valid, based on ex2 multiple participant_id column annotations                   | fail*  |
 

--- a/bagelbids/tests/data/example8.json
+++ b/bagelbids/tests/data/example8.json
@@ -1,0 +1,52 @@
+{
+    "participant_id": {
+        "Description": "A participant ID",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "nb:ParticipantID",
+                "Label": "Unique participant identifier"
+            }
+        }
+    },
+    "alt_participant_id": {
+        "Description": "A participant ID",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "nb:ParticipantID",
+                "Label": "Unique participant identifier"
+            }
+        }
+    },
+    "session_id": {
+        "Description": "A session ID",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "nb:SessionID",
+                "Label": "Unique session identifier"
+            }
+        }
+    },
+    "group": {
+        "Description": "Group variable",
+        "Levels": {
+            "PAT": "Patient",
+            "CTRL": "Control subject"
+        },
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "nb:diagnosis",
+                "Label": "Diagnosis"
+            },
+            "Levels": {
+                "PAT": {
+                    "TermURL": "snomed:49049000",
+                    "Label": "Parkinson's disease"
+                },
+                "CTRL": {
+                    "TermURL": "purl:NCIT_C94342",
+                    "Label": "Healthy Control"
+                }
+            }
+        }
+    }
+}

--- a/bagelbids/tests/data/example8.tsv
+++ b/bagelbids/tests/data/example8.tsv
@@ -1,0 +1,5 @@
+participant_id	alt_participant_id	session_id	group
+sub-01	alt_sub-01	ses-01	PAT
+sub-01	alt_sub-01	ses-02	PAT
+sub-02	alt_sub-02	ses-01	CTRL
+sub-02	alt_sub-02	ses-02	CTRL

--- a/bagelbids/tests/data/example_invalid.tsv
+++ b/bagelbids/tests/data/example_invalid.tsv
@@ -1,0 +1,5 @@
+participant_id	session_id	group
+sub-01	ses-01	PAT
+sub-01	ses-02	PAT
+sub-02	ses-01	CTRL
+sub-02	ses-02	CTRL

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -4,7 +4,8 @@ import pandas as pd
 import pytest
 from typer.testing import CliRunner
 
-from bagelbids.cli import bagel, are_inputs_compatible
+from bagelbids import mappings
+from bagelbids.cli import bagel, are_inputs_compatible, get_columns_about
 
 
 @pytest.fixture
@@ -62,3 +63,13 @@ def test_validate_input(test_data, example, is_valid):
 
     result = are_inputs_compatible(data_dict=data_dict, pheno_df=pheno)
     assert result == is_valid
+
+
+def test_get_columns_that_are_about_concept(test_data):
+    """Test that matching annotated columns are returned as a list, 
+    and that empty list is returned if nothing matches"""
+    with open(test_data / f"example1.json", "r") as f:
+        data_dict = json.load(f)
+    
+    assert ["participant_id"] == get_columns_about(data_dict, concept=mappings.NEUROBAGEL["participant"])
+    assert [] == get_columns_about(data_dict, concept="does not exist concept")


### PR DESCRIPTION
Closes #34 

New functionality:
- `get_columns_about` to grab column names that are annotated with a specific category / concept that we know about (here only `participant_id` is used)
- validation that only one participant and session ID column each are provided (because we cannot yet deal with more than one)
- subject-level parsing of a provided .tsv
- serialization of a neurobagel Dataset instance

Note: 
- we currently don't parse any information inside of the .tsv file because we don't yet know how to deal with things like "age", "sex", etc (that comes next)
- we currently completely ignore sessions (not even creating session instances in the graph or output). That's partly because we have nothing yet to say about sessions (other than that they exist) and partly because session currently require acquisitions - which we do not know about here (pheno)

Also: apologies, this is a long one!