### PR TITLE
Add sex attribute

### DIFF
--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -38,7 +38,10 @@ def get_columns_about(data_dict: dict, concept: str) -> list:
 
 
 def map_categories_to_columns(data_dict: dict) -> dict:
-    """Create a mapping of categories to columns for a given data dictionary"""
+    """
+    Maps all pre-defined Neurobagel categories (e.g. "Sex") to a list of column names (if any) that
+    have been linked to this category.
+    """
     return {
         cat_name: get_columns_about(data_dict, cat_iri)
         for cat_name, cat_iri in mappings.NEUROBAGEL.items()
@@ -60,9 +63,10 @@ def is_column_categorical(column: str, data_dict: dict) -> bool:
     return False
 
 
-def transform_categorical_value(
+def map_cat_val_to_term(
     value: Union[str, int], column: str, data_dict: dict
 ) -> str:
+    """Take a raw categorical value and return the controlled term it has been mapped to"""
     return data_dict[column]["Annotations"]["Levels"][value]["TermURL"]
 
 
@@ -77,9 +81,7 @@ def get_transformed_values(
         if is_missing_value(value, col, data_dict):
             continue
         if is_column_categorical(col, data_dict):
-            _transf_val.append(
-                transform_categorical_value(value, col, data_dict)
-            )
+            _transf_val.append(map_cat_val_to_term(value, col, data_dict))
 
     # TODO: once we can handle multiple columns, this section shoud be removed
     # and we should just return an empty list if no transform can be generated

--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -36,6 +36,15 @@ def get_columns_about(data_dict: dict, concept: str) -> list:
     ]
 
 
+def map_categories_to_columns(data_dict: dict) -> dict:
+    """Create a mapping of categories to columns for a given data dictionary"""
+    return {
+        cat_name: get_columns_about(data_dict, cat_iri)
+        for cat_name, cat_iri in mappings.NEUROBAGEL.items()
+        if get_columns_about(data_dict, cat_iri)
+    }
+
+
 def load_json(input_p: Path) -> dict:
     with open(input_p, "r") as f:
         return json.load(f)
@@ -135,10 +144,10 @@ def pheno(
 
     subject_list = []
 
+    column_mapping = map_categories_to_columns(data_dictionary)
     # TODO: needs refactoring once we handle multiple participant IDs
-    participants = get_columns_about(
-        data_dictionary, concept=mappings.NEUROBAGEL["participant"]
-    )[0]
+    participants = column_mapping.get("participant")[0]
+
     for participant in pheno_df[participants].unique():
         pheno_df.query(f"{participants} == '{str(participant)}'")
         # TODO: needs refactoring once we handle phenotypic information at the session level

--- a/bagelbids/mappings.py
+++ b/bagelbids/mappings.py
@@ -11,4 +11,9 @@ NIDM = {
     "dti": "nidm:DiffusionTensor",
     "asl": "nidm:ArterialSpinLabeling",
 }
-NEUROBAGEL = {"participant": "nb:ParticipantID", "session": "nb:SessionID"}
+NEUROBAGEL = {
+    "participant": "bg:ParticipantID",
+    "session": "bg:SessionID",
+    "sex": "bg:sex",
+    "diagnosis": "bg:diagnosis",
+}

--- a/bagelbids/tests/data/example1.json
+++ b/bagelbids/tests/data/example1.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:ParticipantID",
+                "TermURL": "bg:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:SessionID",
+                "TermURL": "bg:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:diagnosis",
+                "TermURL": "bg:diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagelbids/tests/data/example2.json
+++ b/bagelbids/tests/data/example2.json
@@ -1,43 +1,66 @@
 {
-    "participant_id": {
-        "Description": "A participant ID",
-        "Annotations": {
-            "IsAbout": {
-                "TermURL": "nb:ParticipantID",
-                "Label": "Unique participant identifier"
-            }
-        }
-    },
-    "session_id": {
-        "Description": "A session ID",
-        "Annotations": {
-            "IsAbout": {
-                "TermURL": "nb:SessionID",
-                "Label": "Unique session identifier"
-            }
-        }
-    },
-    "group": {
-        "Description": "Group variable",
-        "Levels": {
-            "PAT": "Patient",
-            "CTRL": "Control subject"
-        },
-        "Annotations": {
-            "IsAbout": {
-                "TermURL": "nb:diagnosis",
-                "Label": "Diagnosis"
-            },
-            "Levels": {
-                "PAT": {
-                    "TermURL": "snomed:49049000",
-                    "Label": "Parkinson's disease"
-                },
-                "CTRL": {
-                    "TermURL": "purl:NCIT_C94342",
-                    "Label": "Healthy Control"
-                }
-            }
-        }
+  "participant_id": {
+    "Description": "A participant ID",
+    "Annotations": {
+      "IsAbout": {
+        "TermURL": "bg:ParticipantID",
+        "Label": "Unique participant identifier"
+      }
     }
+  },
+  "session_id": {
+    "Description": "A session ID",
+    "Annotations": {
+      "IsAbout": {
+        "TermURL": "bg:SessionID",
+        "Label": "Unique session identifier"
+      }
+    }
+  },
+  "group": {
+    "Description": "Group variable",
+    "Levels": {
+      "PAT": "Patient",
+      "CTRL": "Control subject"
+    },
+    "Annotations": {
+      "IsAbout": {
+        "TermURL": "bg:diagnosis",
+        "Label": "Diagnosis"
+      },
+      "Levels": {
+        "PAT": {
+          "TermURL": "snomed:49049000",
+          "Label": "Parkinson's disease"
+        },
+        "CTRL": {
+          "TermURL": "purl:NCIT_C94342",
+          "Label": "Healthy Control"
+        }
+      }
+    }
+  },
+  "sex": {
+    "Description": "Sex variable",
+    "Levels": {
+      "M": "Male",
+      "F": "Female"
+    },
+    "Annotations": {
+      "IsAbout": {
+        "TermURL": "bg:sex",
+        "Label": "Sex"
+      },
+      "Levels": {
+        "M": {
+          "TermURL": "bids:Male",
+          "Label": "Male"
+        },
+        "F": {
+          "TermURL": "bids:Female",
+          "Label": "Female"
+        }
+      }
+    }
+  }
 }

--- a/bagelbids/tests/data/example2.tsv
+++ b/bagelbids/tests/data/example2.tsv
@@ -1,5 +1,5 @@
-participant_id	session_id	group
-sub-01	ses-01	PAT
-sub-01	ses-02	PAT
-sub-02	ses-01	CTRL
-sub-02	ses-02	CTRL
+participant_id	session_id	group	sex
+sub-01	ses-01	PAT	M
+sub-01	ses-02	PAT	M
+sub-02	ses-01	CTRL	F
+sub-02	ses-02	CTRL	F

--- a/bagelbids/tests/data/example4.json
+++ b/bagelbids/tests/data/example4.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:ParticipantID",
+                "TermURL": "bg:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:SessionID",
+                "TermURL": "bg:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:diagnosis",
+                "TermURL": "bg:diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagelbids/tests/data/example5.json
+++ b/bagelbids/tests/data/example5.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:ParticipantID",
+                "TermURL": "bg:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:SessionID",
+                "TermURL": "bg:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:diagnosis",
+                "TermURL": "bg:diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagelbids/tests/data/example6.json
+++ b/bagelbids/tests/data/example6.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:ParticipantID",
+                "TermURL": "bg:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:SessionID",
+                "TermURL": "bg:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:diagnosis",
+                "TermURL": "bg:diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagelbids/tests/data/example7.json
+++ b/bagelbids/tests/data/example7.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:ParticipantID",
+                "TermURL": "bg:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:SessionID",
+                "TermURL": "bg:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:diagnosis",
+                "TermURL": "bg:diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagelbids/tests/data/example8.json
+++ b/bagelbids/tests/data/example8.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:ParticipantID",
+                "TermURL": "bg:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:ParticipantID",
+                "TermURL": "bg:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -21,7 +21,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:SessionID",
+                "TermURL": "bg:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -34,7 +34,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "nb:diagnosis",
+                "TermURL": "bg:diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -1,10 +1,16 @@
 import json
 
+import pandas as pd
 import pytest
 from typer.testing import CliRunner
 
 from bagelbids import mappings
-from bagelbids.cli import bagel, get_columns_about, map_categories_to_columns
+from bagelbids.cli import (
+    bagel,
+    get_cat_transf_val,
+    get_columns_about,
+    map_categories_to_columns,
+)
 
 
 @pytest.fixture
@@ -96,6 +102,18 @@ def test_map_columns(test_data):
     assert ["participant_id"] == result["participant"]
     assert ["session_id"] == result["session"]
     assert ["sex"] == result["sex"]
+
+
+def test_get_transformed_categorical_value(test_data):
+    """Test that the correct transformed value is returned for a categorical variable"""
+    with open(test_data / "example2.json", "r") as f:
+        data_dict = json.load(f)
+
+    assert "bids:Male" == get_cat_transf_val(
+        columns=["sex"],
+        row=pd.Series({"sex": "M"}, index=["sex"]),
+        data_dict=data_dict,
+    )
 
 
 def test_that_output_file_contains_name(runner, test_data, tmp_path):

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -7,8 +7,9 @@ from typer.testing import CliRunner
 from bagelbids import mappings
 from bagelbids.cli import (
     bagel,
-    get_cat_transf_val,
     get_columns_about,
+    get_transformed_values,
+    is_missing_value,
     map_categories_to_columns,
 )
 
@@ -98,7 +99,7 @@ def test_map_columns(test_data):
 
     result = map_categories_to_columns(data_dict)
 
-    assert set(["participant", "session", "sex"]).issubset(result.keys())
+    assert {"participant", "session", "sex"}.issubset(result.keys())
     assert ["participant_id"] == result["participant"]
     assert ["session_id"] == result["session"]
     assert ["sex"] == result["sex"]
@@ -109,10 +110,29 @@ def test_get_transformed_categorical_value(test_data):
     with open(test_data / "example2.json", "r") as f:
         data_dict = json.load(f)
 
-    assert "bids:Male" == get_cat_transf_val(
+    assert "bids:Male" == get_transformed_values(
         columns=["sex"],
         row=pd.Series({"sex": "M"}, index=["sex"]),
         data_dict=data_dict,
+    )
+
+
+def test_missing_values():
+    """Test that missing values are correctly detected"""
+    test_data_dict = {
+        "test_column": {"Annotations": {"MissingValues": ["test_value"]}},
+        "empty_column": {"Annotations": {}},
+    }
+
+    assert (
+        is_missing_value("test_value", "test_column", test_data_dict) is True
+    )
+    assert (
+        is_missing_value("does not exist", "test_column", test_data_dict)
+        is False
+    )
+    assert (
+        is_missing_value("my_value", "empty_column", test_data_dict) is False
     )
 
 

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -4,7 +4,7 @@ import pytest
 from typer.testing import CliRunner
 
 from bagelbids import mappings
-from bagelbids.cli import bagel, get_columns_about
+from bagelbids.cli import bagel, get_columns_about, map_categories_to_columns
 
 
 @pytest.fixture
@@ -83,6 +83,19 @@ def test_get_columns_that_are_about_concept(test_data):
         data_dict, concept=mappings.NEUROBAGEL["participant"]
     )
     assert [] == get_columns_about(data_dict, concept="does not exist concept")
+
+
+def test_map_columns(test_data):
+    """Test that inverse mapping of concepts to columns is correctly created"""
+    with open(test_data / "example2.json", "r") as f:
+        data_dict = json.load(f)
+
+    result = map_categories_to_columns(data_dict)
+
+    assert set(["participant", "session", "sex"]).issubset(result.keys())
+    assert ["participant_id"] == result["participant"]
+    assert ["session_id"] == result["session"]
+    assert ["sex"] == result["sex"]
 
 
 def test_that_output_file_contains_name(runner, test_data, tmp_path):

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -109,31 +109,31 @@ def test_get_transformed_categorical_value(test_data):
     """Test that the correct transformed value is returned for a categorical variable"""
     with open(test_data / "example2.json", "r") as f:
         data_dict = json.load(f)
+    pheno = pd.read_csv(test_data / "example2.tsv", sep="\t")
 
     assert "bids:Male" == get_transformed_values(
         columns=["sex"],
-        row=pd.Series({"sex": "M"}, index=["sex"]),
+        row=pheno.iloc[0],
         data_dict=data_dict,
     )
 
 
-def test_missing_values():
+@pytest.mark.parametrize(
+    "value,column,expected",
+    [
+        ("test_value", "test_column", True),
+        ("does not exist", "test_column", False),
+        ("my_value", "empty_column", False),
+    ],
+)
+def test_missing_values(value, column, expected):
     """Test that missing values are correctly detected"""
     test_data_dict = {
         "test_column": {"Annotations": {"MissingValues": ["test_value"]}},
         "empty_column": {"Annotations": {}},
     }
 
-    assert (
-        is_missing_value("test_value", "test_column", test_data_dict) is True
-    )
-    assert (
-        is_missing_value("does not exist", "test_column", test_data_dict)
-        is False
-    )
-    assert (
-        is_missing_value("my_value", "empty_column", test_data_dict) is False
-    )
+    assert is_missing_value(value, column, test_data_dict) is expected
 
 
 def test_that_output_file_contains_name(runner, test_data, tmp_path):


### PR DESCRIPTION
Closes #41 

Implements parser for the `sex` attribute. Because `"sex"` (and all other phenotypic attributes) are still attached to the subject, if there are multiple rows per subject in the `pheno.tsv` file, we only process the first one.

Also: me figuring our type hinting on python 3.9. At least we now have a good reason for testing multiple versions!