### PR TITLE
Implement handling of diagnosis attributes

### DIFF
--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -214,7 +214,7 @@ def pheno(
             if _dx_val is None:
                 pass
             elif _dx_val == mappings.NEUROBAGEL["healthy_control"]:
-                pass
+                subject.isSubjectGroup = mappings.NEUROBAGEL["healthy_control"]
             else:
                 subject.diagnosis = [models.Diagnosis(identifier=_dx_val)]
 

--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -207,9 +207,20 @@ def pheno(
             subject.sex = get_transformed_values(
                 column_mapping["sex"], _sub_pheno, data_dictionary
             )
+        if "diagnosis" in column_mapping.keys():
+            _dx_val = get_transformed_values(
+                column_mapping["diagnosis"], _sub_pheno, data_dictionary
+            )
+            if _dx_val is None:
+                pass
+            elif _dx_val == mappings.NEUROBAGEL["healthy_control"]:
+                pass
+            else:
+                subject.diagnosis = [models.Diagnosis(identifier=_dx_val)]
+
         subject_list.append(subject)
 
     dataset = models.Dataset(label=name, hasSamples=subject_list)
 
     with open(output / "pheno.jsonld", "w") as f:
-        f.write(dataset.json(indent=2))
+        f.write(dataset.json(indent=2, exclude_unset=True))

--- a/bagelbids/mappings.py
+++ b/bagelbids/mappings.py
@@ -16,4 +16,5 @@ NEUROBAGEL = {
     "session": "bg:SessionID",
     "sex": "bg:sex",
     "diagnosis": "bg:diagnosis",
+    "healthy_control": "purl:NCIT_C94342",
 }

--- a/bagelbids/models.py
+++ b/bagelbids/models.py
@@ -43,6 +43,7 @@ class Subject(Bagel):
     hasSession: Optional[List[Session]] = None
     age: Optional[float] = None
     sex: Optional[str] = None
+    isSubjectGroup: Optional[str] = None
     diagnosis: Optional[List[Diagnosis]] = None
     schemaKey: Literal["Subject"] = Field("Subject", readOnly=True)
 

--- a/bagelbids/tests/data/example6.tsv
+++ b/bagelbids/tests/data/example6.tsv
@@ -2,4 +2,6 @@ participant_id	session_id	group
 sub-01	ses-01	PAT
 sub-01	ses-02	PAT
 sub-02	ses-01	OTHER
-sub-02	ses-02	CTRL
+sub-02	ses-02	OTHER
+sub-03	ses-01	CTRL
+sub-03	ses-02	CTRL

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -181,3 +181,4 @@ def test_diagnosis_and_control_status_handled(runner, test_data, tmp_path):
     )
     assert "diagnosis" not in pheno["hasSamples"][1].keys()
     assert "diagnosis" not in pheno["hasSamples"][2].keys()
+    assert pheno["hasSamples"][2]["isSubjectGroup"] == "purl:NCIT_C94342"

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -155,3 +155,29 @@ def test_that_output_file_contains_name(runner, test_data, tmp_path):
         pheno = json.load(f)
 
     assert pheno.get("label") == "my_dataset_name"
+
+
+def test_diagnosis_and_control_status_handled(runner, test_data, tmp_path):
+    runner.invoke(
+        bagel,
+        [
+            "--pheno",
+            test_data / "example6.tsv",
+            "--dictionary",
+            test_data / "example6.json",
+            "--output",
+            tmp_path,
+            "--name",
+            "my_dataset_name",
+        ],
+    )
+
+    with open(tmp_path / "pheno.jsonld", "r") as f:
+        pheno = json.load(f)
+
+    assert (
+        pheno["hasSamples"][0]["diagnosis"][0]["identifier"]
+        == "snomed:49049000"
+    )
+    assert "diagnosis" not in pheno["hasSamples"][1].keys()
+    assert "diagnosis" not in pheno["hasSamples"][2].keys()


### PR DESCRIPTION
Closes #42 

This PR enables the CLI to add "diagnosis" information from the phenotypic .tsv to the output file.