### PR TITLE
Adding assessment tool attribute

### DIFF
--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -105,6 +105,19 @@ def get_transformed_values(
     return _transf_val[0]
 
 
+def are_not_missing(columns: list, row: pd.Series, data_dict: dict) -> bool:
+    """
+    Checks that all values in the specified columns are not missing values. This is mainly useful
+    to determine the availability of an assessment tool
+    """
+    return all(
+        [
+            not is_missing_value(value, column, data_dict)
+            for column, value in row[columns].items()
+        ]
+    )
+
+
 def load_json(input_p: Path) -> dict:
     with open(input_p, "r") as f:
         return json.load(f)

--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -217,6 +217,16 @@ def pheno(
                 subject.isSubjectGroup = mappings.NEUROBAGEL["healthy_control"]
             else:
                 subject.diagnosis = [models.Diagnosis(identifier=_dx_val)]
+        if "assessment_tool" in column_mapping.keys():
+            subject.assessment = [
+                models.Assessment(
+                    identifier=get_transformed_values(
+                        column_mapping["assessment_tool"],
+                        _sub_pheno,
+                        data_dictionary,
+                    )
+                )
+            ]
 
         subject_list.append(subject)
 

--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 from pathlib import Path
 from typing import Union
 
@@ -47,6 +48,20 @@ def map_categories_to_columns(data_dict: dict) -> dict:
         for cat_name, cat_iri in mappings.NEUROBAGEL.items()
         if get_columns_about(data_dict, cat_iri)
     }
+
+
+def map_tools_to_columns(data_dict: dict) -> dict:
+    """
+    Return a mapping of all assessment tools described in the data dictionary to the columns that
+    are mapped to it.
+    """
+    out_dict = defaultdict(list)
+    for col, content in data_dict.items():
+        part_of = content["Annotations"].get("IsPartOf")
+        if part_of is not None:
+            out_dict[part_of.get("TermURL")].append(col)
+
+    return out_dict
 
 
 def is_missing_value(

--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -218,6 +218,8 @@ def pheno(
     subject_list = []
 
     column_mapping = map_categories_to_columns(data_dictionary)
+    tool_mapping = map_tools_to_columns(data_dictionary)
+
     # TODO: needs refactoring once we handle multiple participant IDs
     participants = column_mapping.get("participant")[0]
 
@@ -245,16 +247,15 @@ def pheno(
                 subject.isSubjectGroup = mappings.NEUROBAGEL["healthy_control"]
             else:
                 subject.diagnosis = [models.Diagnosis(identifier=_dx_val)]
-        if "assessment_tool" in column_mapping.keys():
-            subject.assessment = [
-                models.Assessment(
-                    identifier=get_transformed_values(
-                        column_mapping["assessment_tool"],
-                        _sub_pheno,
-                        data_dictionary,
-                    )
-                )
+        if tool_mapping:
+            _assessments = [
+                models.Assessment(identifier=tool)
+                for tool, columns in tool_mapping.items()
+                if are_not_missing(columns, _sub_pheno, data_dictionary)
             ]
+            if _assessments:
+                # Only set assignments for the subject if at least one is not missing
+                subject.assessment = _assessments
 
         subject_list.append(subject)
 

--- a/bagelbids/mappings.py
+++ b/bagelbids/mappings.py
@@ -17,4 +17,5 @@ NEUROBAGEL = {
     "sex": "bg:sex",
     "diagnosis": "bg:diagnosis",
     "healthy_control": "purl:NCIT_C94342",
+    "assessment_tool": "bg:Assessment",
 }

--- a/bagelbids/models.py
+++ b/bagelbids/models.py
@@ -34,7 +34,7 @@ class Diagnosis(BaseModel):
 
 class Assessment(BaseModel):
     identifier: Union[str, HttpUrl]
-    schemaKey: Literal["Diagnosis"] = Field("Assessment", readOnly=True)
+    schemaKey: Literal["Assessment"] = Field("Assessment", readOnly=True)
 
 
 class Session(Bagel):

--- a/bagelbids/models.py
+++ b/bagelbids/models.py
@@ -32,6 +32,11 @@ class Diagnosis(BaseModel):
     schemaKey: Literal["Diagnosis"] = Field("Diagnosis", readOnly=True)
 
 
+class Assessment(BaseModel):
+    identifier: Union[str, HttpUrl]
+    schemaKey: Literal["Diagnosis"] = Field("Assessment", readOnly=True)
+
+
 class Session(Bagel):
     label: str
     hasAcquisition: List[Acquisition]
@@ -45,6 +50,7 @@ class Subject(Bagel):
     sex: Optional[str] = None
     isSubjectGroup: Optional[str] = None
     diagnosis: Optional[List[Diagnosis]] = None
+    assessment: Optional[List[Assessment]] = None
     schemaKey: Literal["Subject"] = Field("Subject", readOnly=True)
 
 

--- a/bagelbids/tests/data/README.md
+++ b/bagelbids/tests/data/README.md
@@ -9,7 +9,7 @@ Example inputs to the CLI
 | 3       | same as example 2                                                   | valid BIDS data dictionary, BUT: does not contain Neurobagel `"Annotations"` key | fail   |
 | 4       | valid, has additional columns not described in `.json`              | same as example 1                                                                | pass   |
 | 5       | valid, has additional unique value, not documented in `.json`       | same as example 1                                                                | fail   |
-| 6       | valid, same as example 5                                            | valid, contains `"MissingValues"` attribute for categorical variable             | pass   |
+| 6       | valid, same as example 5. hass annotation tool columns              | valid, contains `"MissingValues"` attribute for categorical variable             | pass   |
 | invalid | valid, only exists to be used together with the (invalid) .json     | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |
 | 7       | has fewer columns than are annotated in `.json`                     | same as example 1                                                                | fail   |
 | 8       | valid, based on ex2 has multiple participant_id columns             | valid, based on ex2 multiple participant_id column annotations                   | fail*  |

--- a/bagelbids/tests/data/README.md
+++ b/bagelbids/tests/data/README.md
@@ -2,16 +2,16 @@
 
 Example inputs to the CLI
 
-| Ex#     | `.tsv`                                                              | `.json`                                                                          | Expect |
-|---------|---------------------------------------------------------------------|----------------------------------------------------------------------------------|--------|
+| Ex#     | `.tsv`                                                             | `.json`                                                                          | Expect |
+|---------|--------------------------------------------------------------------|----------------------------------------------------------------------------------|--------|
 | 1       | invalid, non-unique combinations of `participant` and `session` IDs | valid, has `IsAbout` annotations for `participant` and `session` ID columns      | fail   |
-| 2       | valid, unique `participant` and `session` IDs                       | same as example 1                                                                | pass   |
-| 3       | same as example 2                                                   | valid BIDS data dictionary, BUT: does not contain Neurobagel `"Annotations"` key | fail   |
-| 4       | valid, has additional columns not described in `.json`              | same as example 1                                                                | pass   |
-| 5       | valid, has additional unique value, not documented in `.json`       | same as example 1                                                                | fail   |
-| 6       | valid, same as example 5. hass annotation tool columns              | valid, contains `"MissingValues"` attribute for categorical variable             | pass   |
-| invalid | valid, only exists to be used together with the (invalid) .json     | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |
-| 7       | has fewer columns than are annotated in `.json`                     | same as example 1                                                                | fail   |
-| 8       | valid, based on ex2 has multiple participant_id columns             | valid, based on ex2 multiple participant_id column annotations                   | fail*  |
+| 2       | valid, unique `participant` and `session` IDs                      | same as example 1                                                                | pass   |
+| 3       | same as example 2                                                  | valid BIDS data dictionary, BUT: does not contain Neurobagel `"Annotations"` key | fail   |
+| 4       | valid, has additional columns not described in `.json`             | same as example 1                                                                | pass   |
+| 5       | valid, has additional unique value, not documented in `.json`      | same as example 1                                                                | fail   |
+| 6       | valid, same as example 5. has annotation tool columns              | valid, contains `"MissingValues"` attribute for categorical variable             | pass   |
+| invalid | valid, only exists to be used together with the (invalid) .json    | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |
+| 7       | has fewer columns than are annotated in `.json`                    | same as example 1                                                                | fail   |
+| 8       | valid, based on ex2 has multiple participant_id columns            | valid, based on ex2 multiple participant_id column annotations                   | fail*  |
 
 `* this is expected to fail until we enable multiple participant_ID handling`.

--- a/bagelbids/tests/data/example6.json
+++ b/bagelbids/tests/data/example6.json
@@ -40,5 +40,47 @@
             },
             "MissingValues": ["OTHER"]
         }
+    },
+    "tool_item1": {
+        "Description": "item 1 scores for an imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:1234",
+                "Label": "Imaginary tool"
+            },
+            "MissingValues": ["missing"]
+        }
+    },
+    "tool_item2": {
+        "Description": "item 2 scores for an imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:1234",
+                "Label": "Imaginary tool"
+            },
+            "MissingValues": ["missing"]
+        }
+    },
+    "other_tool_item1": {
+        "Description": "item 1 scores for a different imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:4321",
+                "Label": "A different imaginary tool"
+            },
+            "MissingValues": ["none"]
+        }
     }
 }

--- a/bagelbids/tests/data/example6.tsv
+++ b/bagelbids/tests/data/example6.tsv
@@ -1,7 +1,7 @@
-participant_id	session_id	group
-sub-01	ses-01	PAT
-sub-01	ses-02	PAT
-sub-02	ses-01	OTHER
-sub-02	ses-02	OTHER
-sub-03	ses-01	CTRL
-sub-03	ses-02	CTRL
+participant_id	session_id	group	tool_item1	tool_item2	other_tool_item1
+sub-01	ses-01	PAT	11.0	"missing"	"none"
+sub-01	ses-02	PAT	"missing"	12.0	"very good"
+sub-02	ses-01	OTHER	"missing"	"missing"	"none"
+sub-02	ses-02	OTHER	"missing"	"missing"	"none"
+sub-03	ses-01	CTRL	10.0	8.0	"ok"
+sub-03	ses-02	CTRL	10.0	8.0	"bad"

--- a/bagelbids/tests/data/example6.tsv
+++ b/bagelbids/tests/data/example6.tsv
@@ -1,6 +1,6 @@
 participant_id	session_id	group	tool_item1	tool_item2	other_tool_item1
 sub-01	ses-01	PAT	11.0	"missing"	"none"
-sub-01	ses-02	PAT	"missing"	12.0	"very good"
+sub-01	ses-02	PAT	"missing"	12.0	"none"
 sub-02	ses-01	OTHER	"missing"	"missing"	"none"
 sub-02	ses-02	OTHER	"missing"	"missing"	"none"
 sub-03	ses-01	CTRL	10.0	8.0	"ok"

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -182,3 +182,7 @@ def test_diagnosis_and_control_status_handled(runner, test_data, tmp_path):
     assert "diagnosis" not in pheno["hasSamples"][1].keys()
     assert "diagnosis" not in pheno["hasSamples"][2].keys()
     assert pheno["hasSamples"][2]["isSubjectGroup"] == "purl:NCIT_C94342"
+
+
+def test_assessment_tools():
+    assert False

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from bagelbids import mappings
 from bagelbids.cli import (
+    are_not_missing,
     bagel,
     get_columns_about,
     get_transformed_values,
@@ -195,5 +196,12 @@ def test_diagnosis_and_control_status_handled(runner, test_data, tmp_path):
     assert pheno["hasSamples"][2]["isSubjectGroup"] == "purl:NCIT_C94342"
 
 
-def test_assessment_tools():
-    assert False
+def test_get_assessment_tool_availability(test_data):
+    with open(test_data / "example6.json", "r") as f:
+        data_dict = json.load(f)
+    pheno = pd.read_csv(test_data / "example6.tsv", sep="\t")
+    test_columns = ["tool_item1", "tool_item2"]
+
+    assert are_not_missing(test_columns, pheno.iloc[0], data_dict) is False
+    assert are_not_missing(test_columns, pheno.iloc[2], data_dict) is False
+    assert are_not_missing(test_columns, pheno.iloc[4], data_dict) is True

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -11,6 +11,7 @@ from bagelbids.cli import (
     get_transformed_values,
     is_missing_value,
     map_categories_to_columns,
+    map_tools_to_columns,
 )
 
 
@@ -103,6 +104,16 @@ def test_map_columns(test_data):
     assert ["participant_id"] == result["participant"]
     assert ["session_id"] == result["session"]
     assert ["sex"] == result["sex"]
+
+
+def test_map_tools_to_columns(test_data):
+    with open(test_data / "example6.json", "r") as f:
+        data_dict = json.load(f)
+
+    result = map_tools_to_columns(data_dict)
+
+    assert result["cogAtlas:1234"] == ["tool_item1", "tool_item2"]
+    assert result["cogAtlas:4321"] == ["other_tool_item1"]
 
 
 def test_get_transformed_categorical_value(test_data):


### PR DESCRIPTION
Closes #28 

- Adds new function to create a tool -> column map so we can know what columns have been labeled as `IsPartOf` the same tool.
- Adds a function to assert that for a row in the pheno.tsv and a list of columns, all values are not missing. Our current rule for stating that an assessment tool "is available" for a subject is that none of the columns labeled as "IsPartOf" the respective tool have missing values. This might change at some point.