### PR TITLE
Refactor pheno tests

### DIFF
--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -134,8 +134,8 @@ def transform_age(value: Union[int, float, str], heuristic: str) -> float:
         return float(duration.years + duration.months / 12)
     else:
         raise ValueError(
-            "The provided data dictionary contains an unrecognized age transformation. "
-            'Ensure that its TermURL is one of the "bg:euro", "bg:bounded", "bg:range", "bg:iso8601"].'
+            f"The provided data dictionary contains an unrecognized age transformation: {heuristic}. "
+            'Ensure that the transformation TermURL is one of ["bg:euro", "bg:bounded", "bg:range", "bg:iso8601"].'
         )
 
 

--- a/bagelbids/cli.py
+++ b/bagelbids/cli.py
@@ -132,7 +132,11 @@ def transform_age(value: Union[int, float, str], heuristic: str) -> float:
             value = "P" + value
         duration = isodate.parse_duration(value)
         return float(duration.years + duration.months / 12)
-    # TODO: raise Exception, probably ValueError, if heuristic is something we don't know how to handle
+    else:
+        raise ValueError(
+            "The provided data dictionary contains an unrecognized age transformation. "
+            'Ensure that its TermURL is one of the "bg:euro", "bg:bounded", "bg:range", "bg:iso8601"].'
+        )
 
 
 def get_transformed_values(

--- a/bagelbids/tests/conftest.py
+++ b/bagelbids/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from pathlib import Path
 
@@ -17,6 +18,15 @@ def bids_synthetic(bids_path):
 @pytest.fixture(scope="session")
 def test_data():
     return Path(__file__).absolute().parent / "data"
+
+
+@pytest.fixture(scope="session")
+def load_test_json():
+    def _read_file(file_path):
+        with open(file_path, "r") as f:
+            return json.load(f)
+
+    return _read_file
 
 
 @pytest.fixture(scope="session")

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 from typer.testing import CliRunner
 
@@ -9,16 +7,6 @@ from bagelbids.cli import bagel
 @pytest.fixture
 def runner():
     return CliRunner()
-
-
-@pytest.fixture
-def load_tmp_jsonld(tmp_path):
-    def _read_file():
-        with open(tmp_path / "pheno.jsonld", "r") as f:
-            pheno = json.load(f)
-            return pheno
-
-    return _read_file
 
 
 @pytest.mark.parametrize(
@@ -85,7 +73,7 @@ def test_invalid_inputs_are_handled_gracefully(
 
 
 def test_that_output_file_contains_name(
-    runner, test_data, tmp_path, load_tmp_jsonld
+    runner, test_data, tmp_path, load_test_json
 ):
     runner.invoke(
         bagel,
@@ -101,13 +89,13 @@ def test_that_output_file_contains_name(
         ],
     )
 
-    pheno = load_tmp_jsonld()
+    pheno = load_test_json(tmp_path / "pheno.jsonld")
 
     assert pheno.get("label") == "my_dataset_name"
 
 
 def test_diagnosis_and_control_status_handled(
-    runner, test_data, tmp_path, load_tmp_jsonld
+    runner, test_data, tmp_path, load_test_json
 ):
     runner.invoke(
         bagel,
@@ -123,7 +111,7 @@ def test_diagnosis_and_control_status_handled(
         ],
     )
 
-    pheno = load_tmp_jsonld()
+    pheno = load_test_json(tmp_path / "pheno.jsonld")
 
     assert (
         pheno["hasSamples"][0]["diagnosis"][0]["identifier"]
@@ -149,7 +137,7 @@ def test_diagnosis_and_control_status_handled(
     ],
 )
 def test_assessment_data_are_parsed_correctly(
-    runner, test_data, tmp_path, load_tmp_jsonld, assessment, subject
+    runner, test_data, tmp_path, load_test_json, assessment, subject
 ):
     runner.invoke(
         bagel,
@@ -165,7 +153,7 @@ def test_assessment_data_are_parsed_correctly(
         ],
     )
 
-    pheno = load_tmp_jsonld()
+    pheno = load_test_json(tmp_path / "pheno.jsonld")
 
     assert assessment == pheno["hasSamples"][subject].get("assessment")
 
@@ -175,7 +163,7 @@ def test_assessment_data_are_parsed_correctly(
     [(20.5, 0), (pytest.approx(25.66, 0.01), 1)],
 )
 def test_cli_age_is_processed(
-    runner, test_data, tmp_path, load_tmp_jsonld, expected_age, subject
+    runner, test_data, tmp_path, load_test_json, expected_age, subject
 ):
     runner.invoke(
         bagel,
@@ -191,12 +179,12 @@ def test_cli_age_is_processed(
         ],
     )
 
-    pheno = load_tmp_jsonld()
+    pheno = load_test_json(tmp_path / "pheno.jsonld")
 
     assert expected_age == pheno["hasSamples"][subject]["age"]
 
 
-def test_output_includes_context(runner, test_data, tmp_path, load_tmp_jsonld):
+def test_output_includes_context(runner, test_data, tmp_path, load_test_json):
     runner.invoke(
         bagel,
         [
@@ -211,7 +199,7 @@ def test_output_includes_context(runner, test_data, tmp_path, load_tmp_jsonld):
         ],
     )
 
-    pheno = load_tmp_jsonld()
+    pheno = load_test_json(tmp_path / "pheno.jsonld")
 
     assert pheno.get("@context") is not None
     assert all(

--- a/bagelbids/tests/test_cli_pheno.py
+++ b/bagelbids/tests/test_cli_pheno.py
@@ -1,25 +1,34 @@
 import json
 
-import pandas as pd
 import pytest
 from typer.testing import CliRunner
 
-from bagelbids import mappings
-from bagelbids.cli import (
-    are_not_missing,
-    bagel,
-    get_columns_about,
-    get_transformed_values,
-    is_missing_value,
-    map_categories_to_columns,
-    map_tools_to_columns,
-    transform_age,
-)
+from bagelbids.cli import bagel
 
 
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+@pytest.fixture
+def load_tmp_jsonld(tmp_path):
+    def _read_file():
+        with open(tmp_path / "pheno.jsonld", "r") as f:
+            pheno = json.load(f)
+            return pheno
+
+    return _read_file
+
+
+@pytest.fixture
+def load_tmp_jsonld(tmp_path):
+    def _read_file():
+        with open(tmp_path / "pheno.jsonld", "r") as f:
+            pheno = json.load(f)
+            return pheno
+
+    return _read_file
 
 
 @pytest.mark.parametrize(
@@ -85,73 +94,9 @@ def test_invalid_inputs_are_handled_gracefully(
     assert expected_message in str(e.value)
 
 
-def test_get_columns_that_are_about_concept(test_data):
-    """Test that matching annotated columns are returned as a list,
-    and that empty list is returned if nothing matches"""
-    with open(test_data / "example1.json", "r") as f:
-        data_dict = json.load(f)
-
-    assert ["participant_id"] == get_columns_about(
-        data_dict, concept=mappings.NEUROBAGEL["participant"]
-    )
-    assert [] == get_columns_about(data_dict, concept="does not exist concept")
-
-
-def test_map_categories_to_columns(test_data):
-    """Test that inverse mapping of concepts to columns is correctly created"""
-    with open(test_data / "example2.json", "r") as f:
-        data_dict = json.load(f)
-
-    result = map_categories_to_columns(data_dict)
-
-    assert {"participant", "session", "sex"}.issubset(result.keys())
-    assert ["participant_id"] == result["participant"]
-    assert ["session_id"] == result["session"]
-    assert ["sex"] == result["sex"]
-
-
-def test_map_tools_to_columns(test_data):
-    with open(test_data / "example6.json", "r") as f:
-        data_dict = json.load(f)
-
-    result = map_tools_to_columns(data_dict)
-
-    assert result["cogAtlas:1234"] == ["tool_item1", "tool_item2"]
-    assert result["cogAtlas:4321"] == ["other_tool_item1"]
-
-
-def test_get_transformed_categorical_value(test_data):
-    """Test that the correct transformed value is returned for a categorical variable"""
-    with open(test_data / "example2.json", "r") as f:
-        data_dict = json.load(f)
-    pheno = pd.read_csv(test_data / "example2.tsv", sep="\t")
-
-    assert "bids:Male" == get_transformed_values(
-        columns=["sex"],
-        row=pheno.iloc[0],
-        data_dict=data_dict,
-    )
-
-
-@pytest.mark.parametrize(
-    "value,column,expected",
-    [
-        ("test_value", "test_column", True),
-        ("does not exist", "test_column", False),
-        ("my_value", "empty_column", False),
-    ],
-)
-def test_missing_values(value, column, expected):
-    """Test that missing values are correctly detected"""
-    test_data_dict = {
-        "test_column": {"Annotations": {"MissingValues": ["test_value"]}},
-        "empty_column": {"Annotations": {}},
-    }
-
-    assert is_missing_value(value, column, test_data_dict) is expected
-
-
-def test_that_output_file_contains_name(runner, test_data, tmp_path):
+def test_that_output_file_contains_name(
+    runner, test_data, tmp_path, load_tmp_jsonld
+):
     runner.invoke(
         bagel,
         [
@@ -166,13 +111,14 @@ def test_that_output_file_contains_name(runner, test_data, tmp_path):
         ],
     )
 
-    with open(tmp_path / "pheno.jsonld", "r") as f:
-        pheno = json.load(f)
+    pheno = load_tmp_jsonld()
 
     assert pheno.get("label") == "my_dataset_name"
 
 
-def test_diagnosis_and_control_status_handled(runner, test_data, tmp_path):
+def test_diagnosis_and_control_status_handled(
+    runner, test_data, tmp_path, load_tmp_jsonld
+):
     runner.invoke(
         bagel,
         [
@@ -187,8 +133,7 @@ def test_diagnosis_and_control_status_handled(runner, test_data, tmp_path):
         ],
     )
 
-    with open(tmp_path / "pheno.jsonld", "r") as f:
-        pheno = json.load(f)
+    pheno = load_tmp_jsonld()
 
     assert (
         pheno["hasSamples"][0]["diagnosis"][0]["identifier"]
@@ -199,22 +144,9 @@ def test_diagnosis_and_control_status_handled(runner, test_data, tmp_path):
     assert pheno["hasSamples"][2]["isSubjectGroup"] == "purl:NCIT_C94342"
 
 
-def test_get_assessment_tool_availability(test_data):
-    """
-    Ensure that subjects who have one or more missing values in columns mapped to an assessment
-    tool are correctly identified as not having this assessment tool
-    """
-    with open(test_data / "example6.json", "r") as f:
-        data_dict = json.load(f)
-    pheno = pd.read_csv(test_data / "example6.tsv", sep="\t")
-    test_columns = ["tool_item1", "tool_item2"]
-
-    assert are_not_missing(test_columns, pheno.iloc[0], data_dict) is False
-    assert are_not_missing(test_columns, pheno.iloc[2], data_dict) is False
-    assert are_not_missing(test_columns, pheno.iloc[4], data_dict) is True
-
-
-def test_assessment_data_are_parsed_correctly(runner, test_data, tmp_path):
+def test_assessment_data_are_parsed_correctly(
+    runner, test_data, tmp_path, load_tmp_jsonld
+):
     runner.invoke(
         bagel,
         [
@@ -229,8 +161,7 @@ def test_assessment_data_are_parsed_correctly(runner, test_data, tmp_path):
         ],
     )
 
-    with open(tmp_path / "pheno.jsonld", "r") as f:
-        pheno = json.load(f)
+    pheno = load_tmp_jsonld()
 
     assert pheno["hasSamples"][0].get("assessment") is None
     assert pheno["hasSamples"][1].get("assessment") is None
@@ -240,22 +171,7 @@ def test_assessment_data_are_parsed_correctly(runner, test_data, tmp_path):
     ] == pheno["hasSamples"][2].get("assessment")
 
 
-@pytest.mark.parametrize(
-    "raw_age,expected_age,heuristic",
-    [
-        ("11,0", 11.0, "bg:euro"),
-        ("90+", 90.0, "bg:bounded"),
-        ("20-30", 25.0, "bg:range"),
-        ("20Y6M", 20.5, "bg:iso8601"),
-        ("P20Y6M", 20.5, "bg:iso8601"),
-        ("20Y9M", 20.75, "bg:iso8601"),
-    ],
-)
-def test_age_gets_converted(raw_age, expected_age, heuristic):
-    assert expected_age == transform_age(raw_age, heuristic)
-
-
-def test_cli_age_is_processed(runner, test_data, tmp_path):
+def test_cli_age_is_processed(runner, test_data, tmp_path, load_tmp_jsonld):
     runner.invoke(
         bagel,
         [
@@ -270,14 +186,13 @@ def test_cli_age_is_processed(runner, test_data, tmp_path):
         ],
     )
 
-    with open(tmp_path / "pheno.jsonld", "r") as f:
-        pheno = json.load(f)
+    pheno = load_tmp_jsonld()
 
     assert 20.5 == pheno["hasSamples"][0]["age"]
     assert pytest.approx(25.66, 0.01) == pheno["hasSamples"][1]["age"]
 
 
-def test_output_includes_context(runner, test_data, tmp_path):
+def test_output_includes_context(runner, test_data, tmp_path, load_tmp_jsonld):
     runner.invoke(
         bagel,
         [
@@ -292,8 +207,7 @@ def test_output_includes_context(runner, test_data, tmp_path):
         ],
     )
 
-    with open(tmp_path / "pheno.jsonld", "r") as f:
-        pheno = json.load(f)
+    pheno = load_tmp_jsonld()
 
     assert pheno.get("@context") is not None
     assert all(

--- a/bagelbids/tests/test_utility.py
+++ b/bagelbids/tests/test_utility.py
@@ -1,0 +1,116 @@
+import json
+
+import pandas as pd
+import pytest
+
+from bagelbids import mappings
+from bagelbids.cli import (
+    are_not_missing,
+    get_columns_about,
+    get_transformed_values,
+    is_missing_value,
+    map_categories_to_columns,
+    map_tools_to_columns,
+    transform_age,
+)
+
+
+@pytest.fixture
+def load_ex_json(test_data):
+    def _read_file(example_json):
+        with open(test_data / example_json, "r") as f:
+            data_dict = json.load(f)
+            return data_dict
+
+    return _read_file
+
+
+def test_get_columns_that_are_about_concept(load_ex_json):
+    """Test that matching annotated columns are returned as a list,
+    and that empty list is returned if nothing matches"""
+    data_dict = load_ex_json("example1.json")
+
+    assert ["participant_id"] == get_columns_about(
+        data_dict, concept=mappings.NEUROBAGEL["participant"]
+    )
+    assert [] == get_columns_about(data_dict, concept="does not exist concept")
+
+
+def test_map_categories_to_columns(load_ex_json):
+    """Test that inverse mapping of concepts to columns is correctly created"""
+    data_dict = load_ex_json("example2.json")
+
+    result = map_categories_to_columns(data_dict)
+
+    assert {"participant", "session", "sex"}.issubset(result.keys())
+    assert ["participant_id"] == result["participant"]
+    assert ["session_id"] == result["session"]
+    assert ["sex"] == result["sex"]
+
+
+def test_map_tools_to_columns(load_ex_json):
+    data_dict = load_ex_json("example6.json")
+
+    result = map_tools_to_columns(data_dict)
+
+    assert result["cogAtlas:1234"] == ["tool_item1", "tool_item2"]
+    assert result["cogAtlas:4321"] == ["other_tool_item1"]
+
+
+def test_get_transformed_categorical_value(test_data, load_ex_json):
+    """Test that the correct transformed value is returned for a categorical variable"""
+    data_dict = load_ex_json("example2.json")
+    pheno = pd.read_csv(test_data / "example2.tsv", sep="\t")
+
+    assert "bids:Male" == get_transformed_values(
+        columns=["sex"],
+        row=pheno.iloc[0],
+        data_dict=data_dict,
+    )
+
+
+@pytest.mark.parametrize(
+    "value,column,expected",
+    [
+        ("test_value", "test_column", True),
+        ("does not exist", "test_column", False),
+        ("my_value", "empty_column", False),
+    ],
+)
+def test_missing_values(value, column, expected):
+    """Test that missing values are correctly detected"""
+    test_data_dict = {
+        "test_column": {"Annotations": {"MissingValues": ["test_value"]}},
+        "empty_column": {"Annotations": {}},
+    }
+
+    assert is_missing_value(value, column, test_data_dict) is expected
+
+
+def test_get_assessment_tool_availability(test_data, load_ex_json):
+    """
+    Ensure that subjects who have one or more missing values in columns mapped to an assessment
+    tool are correctly identified as not having this assessment tool
+    """
+    data_dict = load_ex_json("example6.json")
+    pheno = pd.read_csv(test_data / "example6.tsv", sep="\t")
+    test_columns = ["tool_item1", "tool_item2"]
+
+    assert are_not_missing(test_columns, pheno.iloc[0], data_dict) is False
+    assert are_not_missing(test_columns, pheno.iloc[2], data_dict) is False
+    assert are_not_missing(test_columns, pheno.iloc[4], data_dict) is True
+
+
+@pytest.mark.parametrize(
+    "raw_age,expected_age,heuristic",
+    [
+        ("11,0", 11.0, "bg:euro"),
+        ("90+", 90.0, "bg:bounded"),
+        ("20-30", 25.0, "bg:range"),
+        ("20Y6M", 20.5, "bg:iso8601"),
+        ("P20Y6M", 20.5, "bg:iso8601"),
+        ("20Y9M", 20.75, "bg:iso8601"),
+    ],
+)
+def test_age_gets_converted(raw_age, expected_age, heuristic):
+    assert expected_age == transform_age(raw_age, heuristic)

--- a/bagelbids/tests/test_utility.py
+++ b/bagelbids/tests/test_utility.py
@@ -133,14 +133,14 @@ def test_age_gets_converted(raw_age, expected_age, heuristic):
 
 
 def test_invalid_age_heuristic():
-    """Given an age transformation that is not recognized, return an informative ValueError."""
+    """Given an age transformation that is not recognized, returns an informative ValueError."""
     with pytest.raises(ValueError) as e:
         transform_age("11,0", "bg:birthyear")
 
     assert "unrecognized age transformation" in str(e.value)
 
 
-# TODO: Probably better to move this function to utility module once it's created, to reuse
+# TODO: Probably better to move this function to utility module once it's created, to reuse.
 def _get_models_fields():
     models_fields_list = []
     for cname, cobj in inspect.getmembers(models, predicate=inspect.isclass):
@@ -153,6 +153,7 @@ def _get_models_fields():
 
 @pytest.mark.parametrize("model_or_field", _get_models_fields())
 def test_generate_context(model_or_field):
+    """Given a model or field in bagelbids.models, generates a corresponding entry in @context."""
     context = generate_context()
 
     assert model_or_field in context["@context"]

--- a/bagelbids/tests/test_utility.py
+++ b/bagelbids/tests/test_utility.py
@@ -48,13 +48,19 @@ def test_map_categories_to_columns(load_ex_json):
     assert ["sex"] == result["sex"]
 
 
-def test_map_tools_to_columns(load_ex_json):
+@pytest.mark.parametrize(
+    "tool, columns",
+    [
+        ("cogAtlas:1234", ["tool_item1", "tool_item2"]),
+        ("cogAtlas:4321", ["other_tool_item1"]),
+    ],
+)
+def test_map_tools_to_columns(load_ex_json, tool, columns):
     data_dict = load_ex_json("example6.json")
 
     result = map_tools_to_columns(data_dict)
 
-    assert result["cogAtlas:1234"] == ["tool_item1", "tool_item2"]
-    assert result["cogAtlas:4321"] == ["other_tool_item1"]
+    assert result[tool] == columns
 
 
 def test_get_transformed_categorical_value(test_data, load_ex_json):
@@ -87,7 +93,13 @@ def test_missing_values(value, column, expected):
     assert is_missing_value(value, column, test_data_dict) is expected
 
 
-def test_get_assessment_tool_availability(test_data, load_ex_json):
+@pytest.mark.parametrize(
+    "subject_idx, is_avail",
+    [(0, False), (2, False), (4, True)],
+)
+def test_get_assessment_tool_availability(
+    test_data, load_ex_json, subject_idx, is_avail
+):
     """
     Ensure that subjects who have one or more missing values in columns mapped to an assessment
     tool are correctly identified as not having this assessment tool
@@ -96,9 +108,10 @@ def test_get_assessment_tool_availability(test_data, load_ex_json):
     pheno = pd.read_csv(test_data / "example6.tsv", sep="\t")
     test_columns = ["tool_item1", "tool_item2"]
 
-    assert are_not_missing(test_columns, pheno.iloc[0], data_dict) is False
-    assert are_not_missing(test_columns, pheno.iloc[2], data_dict) is False
-    assert are_not_missing(test_columns, pheno.iloc[4], data_dict) is True
+    assert (
+        are_not_missing(test_columns, pheno.iloc[subject_idx], data_dict)
+        is is_avail
+    )
 
 
 @pytest.mark.parametrize(

--- a/bagelbids/tests/test_utility.py
+++ b/bagelbids/tests/test_utility.py
@@ -114,3 +114,11 @@ def test_get_assessment_tool_availability(test_data, load_ex_json):
 )
 def test_age_gets_converted(raw_age, expected_age, heuristic):
     assert expected_age == transform_age(raw_age, heuristic)
+
+
+def test_invalid_age_heuristic():
+    """Given an age transformation that is not recognized, return an informative ValueError."""
+    with pytest.raises(ValueError) as e:
+        transform_age("11,0", "bg:birthyear")
+
+    assert "unrecognized age transformation" in str(e.value)


### PR DESCRIPTION
For simplicity, the tests not depending on the CLI runner have been moved to their own test suite first, before any refactoring in  `cli.py`. The PR for issue #59 will address the refactoring of the associated `cli.py` functions into a `utility.py` module.

2 new tests have been added:
- `test_invalid_age_heuristic`
- `test_generate_context`

Closes #52